### PR TITLE
Arch installation method change

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ sudo apt-get install --install-recommends adapta-kde
 
 or download .deb packages from [here](https://launchpad.net/~papirus/+archive/ubuntu/papirus/+packages?field.name_filter=adapta-kde).
 
+### Arch and derivatives
+
+You can install adapta-kde from the official arch repo:
+
+```
+sudo pacman -S adapta-kde kvantum-theme-adapta
+```
+
 ### Adapta KDE Installer
 
 Use the script to install the latest version directly from this repo (independently on your distro):
@@ -53,7 +61,6 @@ Packages in this section are not part of the official repositories. If you have 
 | **Distro** | **Maintainer** | **Package** |
 |:-----------|:---------------|:------------|
 | Arch Linux | Jan Neumann    | [adapta-kde-git](https://aur.archlinux.org/packages/adapta-kde-git/) <sup>AUR</sup> |
-| Arch Linux | Bruno Pagani | `sudo pacman -S adapta-kde kvantum-theme-adapta` <sup>[[link](https://www.archlinux.org/packages/community/any/adapta-kde/)]</sup> |
 | openSUSE | Konstantin Voinov | [adapta-kde](https://software.opensuse.org/download.html?project=home:kill_it&package=adapta-kde) <sup>OBS [[link](https://build.opensuse.org/package/show/home:kill_it/adapta-kde)]</sub> |
 
 **NOTE:** If you maintainer and want be in the list please create an issue or send a pull request.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ You can install adapta-kde from the official arch repo:
 ```
 sudo pacman -S adapta-kde kvantum-theme-adapta
 ```
+You can install git version from the Arch User Repository:
+
+```
+yaourt -S adapta-kde-git
+```
 
 ### Adapta KDE Installer
 


### PR DESCRIPTION
adapta-kde is in official Arch repo now. It does not make any sense to keep it in the unofficial table list.